### PR TITLE
A new feature and two updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,6 +183,19 @@ TestUtils.runParallelMultiArchTest(
             } catch (exc) {
               println "No brew build packages found for NVR ${params.BUILD_NVR}."
             }
+          } else if (params.TASK_ID != '') {
+            try {
+              sh """
+                #!/bin/sh -e
+                NVR=\$(brew taskinfo ${params.TASK_ID} | grep "Build:" | cut -d" " -f2);
+                RPMS=\$(brew buildinfo \${NVR} | grep ${host.arch} | cut -d '/' -f10);
+                for p in \${RPMS}; do echo \${p}; brew download-build --rpm \${p} >/dev/null; done;
+                ls *.rpm;
+                sudo yum --nogpgcheck localinstall -y *.rpm;
+              """
+            } catch (exc) {
+              println "No brew build packages found for TASK_ID ${params.TASK_ID}."
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,6 @@ TestUtils.runParallelMultiArchTest(
       stage ("Install dependencies") {
         sh """
           sudo yum install -y yum-utils
-          sudo yum-config-manager --add-repo https://download.fedoraproject.org/pub/epel/7/${host.arch};
           sudo yum-config-manager --add-repo http://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-7-server.repo;
           sudo yum-config-manager --add-repo http://download-node-02.eng.bos.redhat.com/composes/nightly/EXTRAS-RHEL-7.5/latest-EXTRAS-7.5-RHEL-7/compose/Server/${host.arch}/os;
           sudo yum-config-manager --add-repo http://download-node-02.eng.bos.redhat.com/rel-eng/updates/RHEL-7.5/latest-RHEL-7/compose/Server/${host.arch}/os/;
@@ -114,7 +113,6 @@ TestUtils.runParallelMultiArchTest(
           sudo yum-config-manager --add-repo http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/OpenStack/12.0-RHEL-7/latest/RH7-RHOS-12.0/${host.arch}/os/;
           sudo rpm --import http://download.eng.bos.redhat.com/composes/nightly/EXTRAS-RHEL-7.5/latest-EXTRAS-7.5-RHEL-7/compose/Server/${host.arch}/os/RPM-GPG-KEY-redhat-beta;
           sudo rpm --import http://download.eng.bos.redhat.com/composes/nightly/EXTRAS-RHEL-7.5/latest-EXTRAS-7.5-RHEL-7/compose/Server/${host.arch}/os/RPM-GPG-KEY-redhat-release;
-          sudo rpm --import https://getfedora.org/static/352C64E5.txt;
           sudo yum install -y bc git make golang docker jq bind-utils koji brewkoji openvswitch;
           echo "[registries.search]" | sudo tee /etc/containers/registries.conf >/dev/null;
           echo "registries = ['registry.access.redhat.com']" | sudo tee --append /etc/containers/registries.conf >/dev/null;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,11 @@ properties(
           defaultValue: '',
           description: 'Build task ID for which to run the pipeline',
           name: 'TASK_ID'
+        ),
+        booleanParam(
+          name: 'USE_CTR',
+          defaultValue: true,
+          description: 'Switch between using createTaskRepo plugin (default) or brew/koji method to retrieve packages of a build.'
         )
       ]
     )
@@ -126,33 +131,59 @@ TestUtils.runParallelMultiArchTest(
           sudo docker info
           env | sort
         """
-        if (params.CI_MESSAGE != '') {
-          tid = getTaskId(params.CI_MESSAGE)
-          createTaskRepo taskIds: tid
-        } else if (params.BUILD_NVR != '') {
-          try {
-            tid = sh (
-              script: """brew buildinfo ${params.BUILD_NVR} | grep Task | cut -f2 -d' '""",
-              returnStdout: true
-            ).trim()
+        if (params.USE_CTR) {
+          if (params.CI_MESSAGE != '') {
+            tid = getTaskId(params.CI_MESSAGE)
             createTaskRepo taskIds: tid
-          } catch (exc) {
-            println "No brew build info found for NVR ${params.BUILD_NVR}."
+          } else if (params.BUILD_NVR != '') {
+            try {
+              tid = sh (
+                script: """brew buildinfo ${params.BUILD_NVR} | grep Task | cut -f2 -d' '""",
+                returnStdout: true
+              ).trim()
+              createTaskRepo taskIds: tid
+            } catch (exc) {
+              println "No brew build info found for NVR ${params.BUILD_NVR}."
+            }
+          } else if (params.TASK_ID != '') {
+            createTaskRepo taskIds: params.TASK_ID
           }
-        } else if (params.TASK_ID != '') {
-          createTaskRepo taskIds: params.TASK_ID
-        }
-        try {
-          sh """
-            cat task-repo.properties
-            URL=\$(cat task-repo.properties | grep TASK_REPO_URLS= | sed 's/TASK_REPO_URLS=//' | sed 's/;/\\n/g' | grep ${host.arch})
-            sudo yum-config-manager --add-repo \${URL}
-            REPO=\$(sudo yum repolist | grep atomic-openshift | cut -f1 -d" ")
-            PKGS=\$(sudo yum --disablerepo="*" --enablerepo="\${REPO}" list available | grep atomic | cut -f1 -d" " | paste -sd " " -)
-            sudo yum --nogpgcheck install -y \$(echo \${PKGS})
-          """
-        } catch (exc) {
-          println "Failed to download and install brew build packages."
+          try {
+            sh """
+              cat task-repo.properties
+              URL=\$(cat task-repo.properties | grep TASK_REPO_URLS= | sed 's/TASK_REPO_URLS=//' | sed 's/;/\\n/g' | grep ${host.arch})
+              sudo yum-config-manager --add-repo \${URL}
+              REPO=\$(sudo yum repolist | grep atomic-openshift | cut -f1 -d" ")
+              PKGS=\$(sudo yum --disablerepo="*" --enablerepo="\${REPO}" list available | grep atomic | cut -f1 -d" " | paste -sd " " -)
+              sudo yum --nogpgcheck install -y \$(echo \${PKGS})
+            """
+          } catch (exc) {
+            println "Failed to download and install brew build packages."
+          }
+        } else {
+          if (params.CI_MESSAGE != '') {
+            getRPMFromCIMessage(params.CI_MESSAGE, host.arch)
+            try {
+              sh """
+                ls *.rpm
+                sudo yum --nogpgcheck localinstall -y *.rpm
+              """
+            } catch (exc) {
+              println "No brew build packages found to install."
+            }
+          } else if (params.BUILD_NVR != '') {
+            try {
+              sh """
+                #!/bin/sh -e
+                RPMS=\$(brew buildinfo ${params.BUILD_NVR} | grep ${host.arch} | cut -d '/' -f10);
+                for p in \${RPMS}; do echo \${p}; brew download-build --rpm \${p} >/dev/null; done;
+                ls *.rpm;
+                sudo yum --nogpgcheck localinstall -y *.rpm;
+              """
+            } catch (exc) {
+              println "No brew build packages found for NVR ${params.BUILD_NVR}."
+            }
+          }
         }
       }
       stage ("Start Cluster") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,7 @@ TestUtils.runParallelMultiArchTest(
           sh """
             sudo mkdir -p /etc/docker/certs.d/kernelci-06.khw.lab.eng.bos.redhat.com
             sudo cp ${REGISTRY_CRT} /etc/docker/certs.d/kernelci-06.khw.lab.eng.bos.redhat.com/
-            sudo oc cluster up --image=kernelci-06.khw.lab.eng.bos.redhat.com/multi-arch/ppc64le-openshift3-ose-control-plane:v3.10
+            sudo oc cluster up --image='kernelci-06.khw.lab.eng.bos.redhat.com/multi-arch/ppc64le-openshift3-ose-\${component}:\${version}' --enable=-web-console
           """
         }
       }
@@ -214,7 +214,7 @@ TestUtils.runParallelMultiArchTest(
         stage ("End to End Tests") {
           sh """
             mkdir _out
-            sudo KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig TEST_REPORT_DIR=./_out /usr/libexec/atomic-openshift/extended.test --ginkgo.v=true --ginkgo.skip="Prometheus|Serial|Flaky|Disruptive|Slow|should be applied to XFS filesystem when a pod is created" --ginkgo.focus="EmptyDir"
+            sudo KUBECONFIG=/var/lib/jenkins/workspace/multiarch-qe/multiarch-ci-test-openshift/openshift.local.clusterup/kube-apiserver/admin.kubeconfig TEST_REPORT_DIR=./_out /usr/libexec/atomic-openshift/extended.test --ginkgo.v=true --ginkgo.focus="k8s" --ginkgo.skip="Spark|Cassandra|Redis|Downward API|Storm|RethinkDB|Hazelcast|should support subPath|Secret"
           """
         }
       } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,9 +200,13 @@ TestUtils.runParallelMultiArchTest(
         }
       }
       stage ("Start Cluster") {
-        sh """
-          sudo oc cluster up --image=docker-registry.engineering.redhat.com/multi-arch/ppc64le-openshift3-ose --version='for-test-3.9'
-        """
+        withCredentials([file(credentialsId: 'redhat-multiarch-qe-registrycrt', variable: 'REGISTRY_CRT')]) {
+          sh """
+            sudo mkdir -p /etc/docker/certs.d/kernelci-06.khw.lab.eng.bos.redhat.com
+            sudo cp ${REGISTRY_CRT} /etc/docker/certs.d/kernelci-06.khw.lab.eng.bos.redhat.com/
+            sudo oc cluster up --image=kernelci-06.khw.lab.eng.bos.redhat.com/multi-arch/ppc64le-openshift3-ose-control-plane:v3.10
+          """
+        }
       }
 
       def failed_stages = []

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,6 +205,7 @@ TestUtils.runParallelMultiArchTest(
             sudo mkdir -p /etc/docker/certs.d/kernelci-06.khw.lab.eng.bos.redhat.com
             sudo cp ${REGISTRY_CRT} /etc/docker/certs.d/kernelci-06.khw.lab.eng.bos.redhat.com/
             sudo oc cluster up --image='kernelci-06.khw.lab.eng.bos.redhat.com/multi-arch/ppc64le-openshift3-ose-\${component}:\${version}' --enable=-web-console
+            sudo oc version
           """
         }
       }


### PR DESCRIPTION
With these changes we

- merge the two ways with which we are able to download RPMs from a brew build (createTaskRepo plugin and via brew/koji) and make them selectable by USE_CTR param
- use the new registry with credentials
- update the set of tests that are known to pass (for ppc64le)
